### PR TITLE
Bluez: unregister-includes option not working

### DIFF
--- a/client/main.c
+++ b/client/main.c
@@ -3060,7 +3060,7 @@ static const struct bt_shell_menu gatt_menu = {
 					"Unregister application service" },
 	{ "register-includes", "<UUID> [handle]", cmd_register_includes,
 					"Register as Included service in." },
-	{ "unregister-includes", "<Service-UUID><Inc-UUID>",
+	{ "unregister-includes", "<Service-UUID> <Inc-UUID>",
 			cmd_unregister_includes,
 				 "Unregister Included service." },
 	{ "register-characteristic",


### PR DESCRIPTION
unregister includes option takes two parameters service uuid and included service uuid, since the space between them is missing the menu option is not working as intended